### PR TITLE
Enhancefeat: add rate limits to absolute and fridge commands

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -181,6 +181,7 @@ class Fun(commands.Cog):
             return template_bytes
 
     @commands.hybrid_command(name="fridge", help="Send a fridge image")
+    @commands.cooldown(1, 15, commands.BucketType.user)
     async def fridge(self, ctx: commands.Context):
         """Send a fridge image (simple utility)."""
         # Generate an image locally so it always works (no external hotlinking).
@@ -402,9 +403,7 @@ class Fun(commands.Cog):
         await ctx.reply(embed=embed, mention_author=False)
 
     @commands.hybrid_command(name="absolute", help="Put your avatar on the 'absolute cinema' GIF")
-
-
-
+    @commands.cooldown(1, 15, commands.BucketType.user)
     @app_commands.describe(text="Text to replace 'cinema' with")
     async def absolute(self, ctx: commands.Context, *, text: str):
 


### PR DESCRIPTION
## Description
This PR introduces rate limits to the `?absolute` and `?fridge` commands to prevent them from being spammed and causing potential raids, as mentioned in the issue. 

A cooldown of 1 usage per 15 seconds per user (`@commands.cooldown(1, 15, commands.BucketType.user)`) has been applied to both commands in `cogs/fun.py`.

Closes #25 

## Changes Made
- Added `@commands.cooldown(1, 15, commands.BucketType.user)` to the `fridge` hybrid command.
- Added `@commands.cooldown(1, 15, commands.BucketType.user)` to the `absolute` hybrid command.

## Impact
- Protects the server and bot by stopping possible raids through spamming these commands.
- Improves moderation functionality without disrupting the user experience.

## Checklist
- [x] I have tested these changes.
- [x] My code follows the style guidelines of this project.
