### PR TITLE
Add help menu descriptions to all commands

### DIFF
--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -147,6 +147,7 @@ class AFKSystem(commands.Cog):
 
     @commands.hybrid_command(
         name="afk",
+        description="Set yourself as AFK with an optional reason",
         help="Set yourself as AFK with an optional reason",
         usage="afk [reason]"
     )
@@ -229,6 +230,7 @@ class AFKSystem(commands.Cog):
 
     @commands.hybrid_command(
         name="afklist",
+        description="List all currently AFK users in the server",
         help="List all currently AFK users in the server",
         aliases=["afkstatus", "whoafk"]
     )

--- a/cogs/bump_leaderboard.py
+++ b/cogs/bump_leaderboard.py
@@ -691,7 +691,7 @@ class BumpLeaderboard(commands.Cog):
     # Prefix-only commands (requested aliases)
     # ----------------------------
 
-    @commands.command(name="mybumps")
+    @commands.command(name="mybumps", help="Show your personal bump stats")
     async def mybumps(self, ctx: commands.Context):
         """Prefix-only: show your bump stats."""
         if ctx.guild is None:
@@ -705,17 +705,17 @@ class BumpLeaderboard(commands.Cog):
         embed.add_field(name="Last bump", value=self._format_full_time(entry.last_bump_time), inline=False)
         await ctx.send(embed=embed)
 
-    @commands.command(name="blb")
+    @commands.command(name="blb", help="Show the bump leaderboard (alias for bumplb)")
     async def blb(self, ctx: commands.Context):
         """Prefix-only alias for bump leaderboard."""
         await self.bumplb(ctx)  # reuse hybrid handler
 
-    @commands.command(name="bst")
+    @commands.command(name="bst", help="Show total bumps and the most recent bumper (alias for bumpstats)")
     async def bst(self, ctx: commands.Context):
         """Prefix-only alias for bump stats."""
         await self.bumpstats(ctx)
 
-    @commands.command(name="topbump")
+    @commands.command(name="topbump", help="Show the top 3 bumpers in the server")
     async def topbump(self, ctx: commands.Context):
         """Prefix-only: show top 3 bumpers."""
         if ctx.guild is None:

--- a/cogs/codebuddy_help.py
+++ b/cogs/codebuddy_help.py
@@ -95,7 +95,7 @@ class CodeBuddyHelpCog(commands.Cog):
         # Edit the original response with the help embed
         await interaction.edit_original_response(content=None, embed=embed, view=view)
 
-    @commands.command(name="quizhelp")
+    @commands.command(name="quizhelp", help="Get help and information about CodeBuddy bot commands")
     async def quizhelp_prefix(self, ctx):
         """Displays help information about all available commands."""
         

--- a/cogs/codebuddy_leaderboard.py
+++ b/cogs/codebuddy_leaderboard.py
@@ -122,7 +122,7 @@ class CodeBuddyLeaderboardCog(commands.Cog):
             except Exception:
                 pass
 
-    @commands.command(name="codeweek", aliases=["cw", "cwlb"])
+    @commands.command(name="codeweek", aliases=["cw", "cwlb"], help="Show the weekly coding leaderboard")
     async def codeweek_prefix(self, ctx):
         """Display the weekly leaderboard."""
         try:
@@ -301,7 +301,7 @@ class CodeBuddyLeaderboardCog(commands.Cog):
             except Exception:
                 pass
 
-    @commands.command(name="codestreak", aliases=["cs", "cslb"])
+    @commands.command(name="codestreak", aliases=["cs", "cslb"], help="Show the coding streak leaderboard")
     async def codestreak_prefix(self, ctx):
         """Display the streak leaderboard."""
         try:

--- a/cogs/codebuddy_quiz.py
+++ b/cogs/codebuddy_quiz.py
@@ -398,7 +398,7 @@ class CodeBuddyQuizCog(commands.Cog):
             except Exception:
                 pass
 
-    @commands.command(name="codeleaderboard", aliases=["clb"])
+    @commands.command(name="codeleaderboard", aliases=["clb"], help="Show the top players with the most correct answers")
     async def codeleaderboard_prefix(self, ctx: commands.Context):
         """Show the top players with the most correct answers."""
         try:
@@ -498,7 +498,7 @@ class CodeBuddyQuizCog(commands.Cog):
             except Exception:
                 pass
 
-    @commands.command(name="codestats", aliases=["cst"])
+    @commands.command(name="codestats", aliases=["cst"], help="Show your personal coding quiz stats")
     async def codestats_prefix(self, ctx: commands.Context):
         """Show your personal coding quiz stats."""
         try:

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -617,7 +617,7 @@ class Counting(commands.Cog):
             await self._clear_highscore_marker_if_any(guild_id, message.channel)
 
 
-    @commands.command(name="donateguild", aliases=["dg"], help="Donate 1 personal save to the guild pool")
+    @commands.command(name="donateguild", aliases=["dg"], help="Donate 0.5 personal save to the guild pool")
     async def donate_guild(self, ctx: commands.Context):
         """Donate 1 personal save to the guild pool (guild receives 0.5 save)."""
         if not ctx.guild:

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -617,7 +617,7 @@ class Counting(commands.Cog):
             await self._clear_highscore_marker_if_any(guild_id, message.channel)
 
 
-    @commands.command(name="donateguild", aliases=["dg"])
+    @commands.command(name="donateguild", aliases=["dg"], help="Donate 1 personal save to the guild pool")
     async def donate_guild(self, ctx: commands.Context):
         """Donate 1 personal save to the guild pool (guild receives 0.5 save)."""
         if not ctx.guild:
@@ -649,7 +649,7 @@ class Counting(commands.Cog):
         )
 
 
-    @commands.command(name="guildsaves", aliases=["gsaves", "serversaves", "ssaves"])
+    @commands.command(name="guildsaves", aliases=["gsaves", "serversaves", "ssaves"], help="Show the server save pool used to protect counting mistakes")
     async def guild_saves(self, ctx: commands.Context):
         """Show the server save pool used to protect counting mistakes."""
         if not ctx.guild:
@@ -661,7 +661,7 @@ class Counting(commands.Cog):
             "(Needs **1.0** server save to protect a ruined count.)"
         )
 
-    @commands.hybrid_command(name="highscoretable", aliases=["highscores"], help="Show recent counting highscores")
+    @commands.hybrid_command(name="highscoretable", aliases=["highscores"], description="Show recent counting highscores", help="Show recent counting highscores")
     async def highscore_table(self, ctx: commands.Context):
         if not ctx.guild:
             return await ctx.send("Server only command.")
@@ -703,7 +703,7 @@ class Counting(commands.Cog):
         embed.description = "\n".join(lines)
         await ctx.send(embed=embed)
 
-    @commands.command(name="mcl", aliases=["tc"])
+    @commands.command(name="mcl", aliases=["tc"], help="Leaderboard of users with the most correct counts")
     async def most_count_leaderboard(self, ctx):
         async with aiosqlite.connect(DB_PATH, timeout=30.0) as db:
             async with db.execute("""
@@ -726,7 +726,7 @@ class Counting(commands.Cog):
         embed.description = description
         await ctx.send(embed=embed)
 
-    @commands.command(name="mrl")
+    @commands.command(name="mrl", help="Leaderboard of users who ruined the count the most")
     async def most_ruined_leaderboard(self, ctx):
         async with aiosqlite.connect(DB_PATH, timeout=30.0) as db:
             async with db.execute("""
@@ -749,7 +749,7 @@ class Counting(commands.Cog):
         embed.description = description
         await ctx.send(embed=embed)
 
-    @commands.command(name="scs")
+    @commands.command(name="scs", help="Show current count and high score for this server")
     async def server_count_stats(self, ctx):
         async with aiosqlite.connect(DB_PATH, timeout=30.0) as db:
             async with db.execute("SELECT current_count, high_score FROM counting_config WHERE guild_id = ?", (ctx.guild.id,)) as cursor:

--- a/cogs/daily_quests.py
+++ b/cogs/daily_quests.py
@@ -20,7 +20,7 @@ class DailyQuestsCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
     
-    @commands.command(name="dailyquest", aliases=["dq", "quests", "quest", "daily", "checklist"])
+    @commands.command(name="dailyquest", aliases=["dq", "quests", "quest", "daily", "checklist"], help="View your daily quest progress and rewards")
     async def daily_quest(self, ctx: commands.Context):
         """
         View your daily quest progress and rewards.
@@ -80,7 +80,7 @@ class DailyQuestsCog(commands.Cog):
             print(f"[Error in daily_quest command]: {e}")
             await ctx.send("An error occurred while fetching your quest progress.", ephemeral=True)
     
-    @commands.command(name="inventory", aliases=["inv", "rewards"])
+    @commands.command(name="inventory", aliases=["inv", "rewards"], help="View your quest rewards inventory")
     async def inventory(self, ctx: commands.Context):
         """View your quest rewards inventory."""
         user_id = ctx.author.id

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -178,7 +178,7 @@ class Fun(commands.Cog):
             )
             return template_bytes
 
-    @commands.hybrid_command(name="fridge", help="Send a fridge image")
+    @commands.hybrid_command(name="fridge", description="Send a fridge image", help="Send a fridge image")
     @commands.cooldown(1, 15, commands.BucketType.user)
     async def fridge(self, ctx: commands.Context):
         """Send a fridge image (simple utility)."""
@@ -227,7 +227,7 @@ class Fun(commands.Cog):
         await ctx.reply(embed=embed, file=file, mention_author=False)
 
     @commands.hybrid_command(
-        name="compliment", help="Receive a professional programming compliment"
+        name="compliment", description="Receive a professional programming compliment", help="Receive a professional programming compliment"
     )
     async def compliment(
         self, ctx: commands.Context, member: Optional[discord.Member] = None
@@ -246,7 +246,7 @@ class Fun(commands.Cog):
         embed.set_footer(text="CodeVerse Bot | Professional Development")
         await ctx.reply(embed=embed, mention_author=False)
 
-    @commands.hybrid_command(name="joke", help="Get a programming-related joke")
+    @commands.hybrid_command(name="joke", description="Get a programming-related joke", help="Get a programming-related joke")
     async def joke(self, ctx: commands.Context):
         """Share a clean programming joke."""
         joke = random.choice(PROGRAMMING_JOKES)
@@ -260,7 +260,7 @@ class Fun(commands.Cog):
         embed.set_footer(text="CodeVerse Bot | Community Fun")
         await ctx.reply(embed=embed, mention_author=False)
 
-    @commands.hybrid_command(name="fortune", help="Get a programming fortune")
+    @commands.hybrid_command(name="fortune", description="Get a programming fortune", help="Get a programming fortune")
     async def fortune(self, ctx: commands.Context):
         """Receive a programming-themed fortune message."""
         fortune = random.choice(FORTUNE_MESSAGES)
@@ -274,7 +274,7 @@ class Fun(commands.Cog):
         embed.set_footer(text="CodeVerse Bot | Daily Inspiration")
         await ctx.reply(embed=embed, mention_author=False)
 
-    @commands.hybrid_command(name="flip", help="Flip a coin")
+    @commands.hybrid_command(name="flip", description="Flip a coin", help="Flip a coin")
     async def flip(self, ctx: commands.Context):
         """Flip a virtual coin."""
         result = random.choice(["Heads", "Tails"])
@@ -314,7 +314,7 @@ class Fun(commands.Cog):
         await ctx.reply(embed=embed, mention_author=False)
 
     @commands.hybrid_command(
-        name="choose", help="Choose randomly from a list of options"
+        name="choose", description="Choose randomly from a list of options", help="Choose randomly from a list of options"
     )
     @app_commands.describe(choices="Comma-separated list of choices")
     async def choose(self, ctx: commands.Context, *, choices: str):
@@ -349,6 +349,7 @@ class Fun(commands.Cog):
         )
         embed.set_footer(text="CodeVerse Bot | Decision Helper")
         await ctx.reply(embed=embed, mention_author=False)
+    @commands.hybrid_command(name="absolute", description="Generate an 'ABSOLUTE cinema' GIF with your text", help="Generate an 'ABSOLUTE cinema' GIF with your text")
     @app_commands.describe(text="Text to replace 'cinema' with")
     async def absolute(self, ctx: commands.Context, *, text: str):
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -491,7 +491,7 @@ class HelpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @commands.command(name="helpmenu", description="Show help for commands or a specific command/cog")
+    @commands.command(name="helpmenu", help="Show help for commands or a specific command/cog")
     async def helpmenu(self, ctx: commands.Context, *, query: Optional[str] = None):
         """Show interactive help menu or detailed help for a specific command/category."""
         await self._show_help(ctx, query)

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -708,7 +708,7 @@ class Misc(commands.Cog):
             ephemeral=True
         )
 
-    @commands.command(name='dm', description='Explains why you should not DM members for help')
+    @commands.command(name='dm', help='Explains why you should not DM members for help')
     async def dm_command(self, ctx: commands.Context):
         """Explains why questions should be asked in the server instead of DMs."""
         message = (

--- a/cogs/staff_applications.py
+++ b/cogs/staff_applications.py
@@ -506,7 +506,7 @@ class StaffApplications(commands.Cog):
         except Exception as e:
             logger.error(f"Failed to load persistent views: {e}")
 
-    @commands.hybrid_command(name="panel", description="Post the staff application panel")
+    @commands.hybrid_command(name="panel", description="Post the staff application panel", help="Post the staff application panel")
     @commands.has_permissions(administrator=True)
     async def panel(self, ctx):
         embed = discord.Embed(

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -41,7 +41,7 @@ class Tags(commands.Cog):
         if ctx.invoked_subcommand is None:
             await ctx.send("Use /tags list or /tag <name>")
 
-    @commands.hybrid_command(name="tag", help="Get a tag by name.")
+    @commands.hybrid_command(name="tag", description="Get a tag by name.", help="Get a tag by name.")
     @app_commands.describe(name="Tag name to fetch")
     @commands.guild_only()
     async def tag(self, ctx: commands.Context, name: str):

--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -941,7 +941,7 @@ class Tickets(commands.Cog):
         except Exception as e:
             print(f"[Tickets] Failed to send log: {e}")
     
-    @commands.hybrid_command(name="ticketpanel")
+    @commands.hybrid_command(name="ticketpanel", description="Create a ticket panel with a button to open tickets", help="Create a ticket panel with a button to open tickets")
     @commands.has_permissions(administrator=True)
     @app_commands.describe(
         channel="Channel to send the ticket panel to",
@@ -1067,7 +1067,7 @@ class Tickets(commands.Cog):
             ephemeral=True
         )
     
-    @commands.hybrid_command(name="ticketlog")
+    @commands.hybrid_command(name="ticketlog", description="Set up or view the ticket log channel", help="Set up or view the ticket log channel")
     @commands.has_permissions(administrator=True)
     @app_commands.describe(
         channel="The channel to use for ticket logs (leave empty to view current setting)"
@@ -1191,7 +1191,7 @@ class Tickets(commands.Cog):
                 ephemeral=True
             )
     
-    @commands.hybrid_command(name="ticketlog-disable")
+    @commands.hybrid_command(name="ticketlog-disable", description="Disable ticket logging for this server", help="Disable ticket logging for this server")
     @commands.has_permissions(administrator=True)
     async def ticket_log_disable(self, ctx):
         """Disable ticket logging for this server"""
@@ -1243,7 +1243,7 @@ class Tickets(commands.Cog):
                 ephemeral=True
             )
     
-    @commands.hybrid_command(name="ticketsupport")
+    @commands.hybrid_command(name="ticketsupport", description="Set up or view the support role for ticket notifications", help="Set up or view the support role for ticket notifications")
     @commands.has_permissions(administrator=True)
     @app_commands.describe(
         role="The role to ping when new tickets are created (leave empty to view current setting)"
@@ -1332,7 +1332,7 @@ class Tickets(commands.Cog):
                 ephemeral=True
             )
     
-    @commands.hybrid_command(name="ticketsupport-disable")
+    @commands.hybrid_command(name="ticketsupport-disable", description="Disable the custom support role for tickets", help="Disable the custom support role for tickets")
     @commands.has_permissions(administrator=True)
     async def ticket_support_role_disable(self, ctx):
         """Disable the custom support role for tickets"""
@@ -1384,7 +1384,7 @@ class Tickets(commands.Cog):
                 ephemeral=True
             )
     
-    @commands.hybrid_command(name="tickets")
+    @commands.hybrid_command(name="tickets", description="View all tickets, filterable by status or user", help="View all tickets, filterable by status or user")
     @commands.has_permissions(manage_messages=True)
     @app_commands.describe(
         status="Filter tickets by status (open, closed, all)",
@@ -1462,7 +1462,7 @@ class Tickets(commands.Cog):
         
         await ctx.send(embed=embed)
     
-    @commands.hybrid_command(name="ticketstats")
+    @commands.hybrid_command(name="ticketstats", description="View ticket statistics for this server", help="View ticket statistics for this server")
     @commands.has_permissions(manage_messages=True)
     async def ticket_stats(self, ctx):
         """View ticket statistics"""
@@ -1512,7 +1512,7 @@ class Tickets(commands.Cog):
         
         await ctx.send(embed=embed)
     
-    @commands.hybrid_command(name="forceclose")
+    @commands.hybrid_command(name="forceclose", description="Force close a ticket by its ID (Staff only)", help="Force close a ticket by its ID (Staff only)")
     @commands.has_permissions(manage_messages=True)
     @app_commands.describe(
         ticket_id="The ID of the ticket to force close",
@@ -1646,7 +1646,7 @@ class Tickets(commands.Cog):
         
         print(f"[Tickets] 🔒 Ticket #{ticket_id} force closed by {ctx.author} - Reason: {reason}")
     
-    @commands.hybrid_command(name="ticketreport")
+    @commands.hybrid_command(name="ticketreport", description="Set up or view the report role for report ticket notifications", help="Set up or view the report role for report ticket notifications")
     @commands.has_permissions(administrator=True)
     @app_commands.describe(
         role="The role to ping when report tickets are created (leave empty to view current setting)"
@@ -1738,7 +1738,7 @@ class Tickets(commands.Cog):
                 ephemeral=True
             )
     
-    @commands.hybrid_command(name="ticketreport-disable")
+    @commands.hybrid_command(name="ticketreport-disable", description="Disable the custom report role for tickets", help="Disable the custom report role for tickets")
     @commands.has_permissions(administrator=True)
     async def ticket_report_role_disable(self, ctx):
         """Disable the custom report role for tickets"""
@@ -1785,7 +1785,7 @@ class Tickets(commands.Cog):
                 ephemeral=True
             )
     
-    @commands.hybrid_command(name="ticketpartner")
+    @commands.hybrid_command(name="ticketpartner", description="Set up or view the partner role for partnership ticket notifications", help="Set up or view the partner role for partnership ticket notifications")
     @commands.has_permissions(administrator=True)
     @app_commands.describe(
         role="The role to ping when partnership tickets are created (leave empty to view current setting)"
@@ -1877,7 +1877,7 @@ class Tickets(commands.Cog):
                 ephemeral=True
             )
     
-    @commands.hybrid_command(name="ticketpartner-disable")
+    @commands.hybrid_command(name="ticketpartner-disable", description="Disable the custom partner role for tickets", help="Disable the custom partner role for tickets")
     @commands.has_permissions(administrator=True)
     async def ticket_partner_role_disable(self, ctx):
         """Disable the custom partner role for tickets"""

--- a/cogs/tod.py
+++ b/cogs/tod.py
@@ -90,11 +90,11 @@ class TOD(commands.Cog):
     async def tod_command(self, ctx: commands.Context):
         await self.send_tod_message(ctx, "random")
 
-    @commands.command(name="truth")
+    @commands.command(name="truth", help="Get a random truth question")
     async def truth_command(self, ctx: commands.Context):
         await self.send_tod_message(ctx, "truth")
 
-    @commands.command(name="dare")
+    @commands.command(name="dare", help="Get a random dare question")
     async def dare_command(self, ctx: commands.Context):
         await self.send_tod_message(ctx, "dare")
 

--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -119,7 +119,7 @@ class Say(commands.Cog):
     # LOGIN TTS NAME
     # ----------------------------
 
-    @commands.hybrid_command(name="logintts")
+    @commands.hybrid_command(name="logintts", description="Set your TTS display name for voice chat", help="Set your TTS display name for voice chat")
     async def logintts(self, ctx: Context, name: str):
         if len(name) > 32:
             return await ctx.send("Name too long. Max 32 characters.")
@@ -139,7 +139,7 @@ class Say(commands.Cog):
     # FORCE LEAVE VC
     # ----------------------------
 
-    @commands.hybrid_command(name="leavevc")
+    @commands.hybrid_command(name="leavevc", description="Make the bot leave its current voice channel", help="Make the bot leave its current voice channel")
     async def leavevc(self, ctx: Context):
         vc = ctx.voice_client
         if isinstance(vc, discord.VoiceClient) and vc.is_connected():
@@ -152,7 +152,7 @@ class Say(commands.Cog):
     # TTS COMMAND
     # ----------------------------
 
-    @commands.hybrid_command(name="tts")
+    @commands.hybrid_command(name="tts", description="Send a text-to-speech message in your voice channel", help="Send a text-to-speech message in your voice channel")
     @commands.cooldown(1, 2, commands.BucketType.user)
     async def tts(self, ctx: Context, *, text: str):
 

--- a/cogs/utility_extra.py
+++ b/cogs/utility_extra.py
@@ -44,7 +44,7 @@ class UtilityExtra(commands.Cog):
         return total if total > 0 else None
 
     # ============ COMMANDS ============
-    @commands.hybrid_command(name="emotes", help="Get a list of server emojis. Optional search.")
+    @commands.hybrid_command(name="emotes", description="Get a list of server emojis. Optional search.", help="Get a list of server emojis. Optional search.")
     @app_commands.describe(search="Optional search text")
     @commands.guild_only()
     async def emotes(self, ctx: commands.Context, *, search: Optional[str] = None):
@@ -59,7 +59,7 @@ class UtilityExtra(commands.Cog):
         display = " ".join(str(e) for e in emojis[:100])  # limit to avoid overflow
         await ctx.reply(f"Emojis ({len(emojis)}):\n{display}")
 
-    @commands.hybrid_command(name="membercount", help="Get the member count of the current server.")
+    @commands.hybrid_command(name="membercount", description="Get the member count of the current server.", help="Get the member count of the current server.")
     @commands.guild_only()
     @app_commands.guild_only()
     async def membercount(self, ctx: commands.Context):
@@ -67,7 +67,7 @@ class UtilityExtra(commands.Cog):
             return await ctx.reply("This command can only be used in a server.")
         await ctx.reply(f"Member Count: {ctx.guild.member_count}")
 
-    @commands.hybrid_command(name="randomcolor", help="Generate a random hex color.")
+    @commands.hybrid_command(name="randomcolor", description="Generate a random hex color.", help="Generate a random hex color.")
     async def randomcolor(self, ctx: commands.Context):
         value = random.randint(0, 0xFFFFFF)
         hex_code = f"#{value:06X}"
@@ -85,7 +85,7 @@ class UtilityExtra(commands.Cog):
         total = sum(rolls)
         await ctx.reply(f"Rolled {count}d{size}: {', '.join(map(str, rolls))} (Total: {total})")
 
-    @commands.hybrid_command(name="remindme", help="Set a reminder. Example: /remindme 10m Submit report")
+    @commands.hybrid_command(name="remindme", description="Set a reminder. Example: /remindme 10m Submit report", help="Set a reminder. Example: /remindme 10m Submit report")
     @app_commands.describe(time="Time span like 10m, 2h, 1d", reminder="Reminder text")
     async def remindme(self, ctx: commands.Context, time: str, *, reminder: str):
         seconds = self.parse_time(time)
@@ -140,7 +140,7 @@ class UtilityExtra(commands.Cog):
             embed.add_field(name="Expires", value=f"<t:{int(invite.expires_at.timestamp())}:R>", inline=True)
         await ctx.reply(embed=embed)
 
-    @commands.hybrid_command(name="avatar", help="Get a user's avatar.")
+    @commands.hybrid_command(name="avatar", description="Get a user's avatar.", help="Get a user's avatar.")
     @app_commands.describe(user="The user to get the avatar of")
     async def avatar(self, ctx: commands.Context, user: Optional[Union[discord.Member, discord.User]] = None):
         target = user or ctx.author
@@ -148,7 +148,7 @@ class UtilityExtra(commands.Cog):
         embed.set_image(url=target.display_avatar.url)
         await ctx.reply(embed=embed)
 
-    @commands.hybrid_command(name="serverinfo", help="Get server info/stats.")
+    @commands.hybrid_command(name="serverinfo", description="Get server info/stats.", help="Get server info/stats.")
     @commands.guild_only()
     async def serverinfo(self, ctx: commands.Context):
         if ctx.guild is None:
@@ -168,7 +168,7 @@ class UtilityExtra(commands.Cog):
         
         await ctx.reply(embed=embed)
 
-    @commands.hybrid_command(name="color", help="Show a color using hex.")
+    @commands.hybrid_command(name="color", description="Show a color using hex.", help="Show a color using hex.")
     @app_commands.describe(hex_code="Hex color code (e.g., #FF0000)")
     async def color(self, ctx: commands.Context, hex_code: str):
         hex_code = hex_code.strip('#')


### PR DESCRIPTION
## Summary
Adds clear, concise descriptions to every command across all cogs so the help menu no longer shows "No description" for any command.
This PR should fix the issue #47

## Changes

### Bug fixes
- Added missing hybrid_command decorator to the absolute command — it was unreachable as a bot command before
- Fixed helpmenu prefix command using description= (invalid for prefix commands) → changed to help=
- Fixed dm prefix command using description= → changed to help=

### Hybrid commands — added description= + help=
- tts: logintts, leavevc, tts
- tickets: ticketpanel, ticketlog, ticketlog-disable, ticketsupport, ticketsupport-disable, tickets, ticketstats, forceclose, ticketreport, ticketreport-disable, ticketpartner, ticketpartner-disable
- fun: fridge, joke, fortune, flip, compliment, choose, absolute
- utility_extra: emotes, membercount, randomcolor, remindme, avatar, serverinfo, color
- afk: afk, afklist
- counting: highscoretable
- tags: tag
- staff_applications: panel

### Prefix-only commands — added help=
- tod: truth, dare
- counting: mcl, mrl, scs, donateguild, guildsaves
- bump_leaderboard: mybumps, blb, bst, topbump
- daily_quests: dailyquest, inventory
- codebuddy_quiz: codeleaderboard, codestats
- codebuddy_leaderboard: codeweek, codestreak
- codebuddy_help: quizhelp

## Notes
- All descriptions are 1–2 sentences, consistent in tone and capitalization with existing entries
- Hybrid commands now have both description= (for slash) and help= (for prefix) to ensure they appear correctly in both interfaces
- Prefix-only commands use help= which feeds short_doc used by the help menu
- No functional behavior changes — only metadata for the help system