### PR TITLE
Removed reset on quiz answers

### DIFF
--- a/utils/codebuddy_database.py
+++ b/utils/codebuddy_database.py
@@ -256,6 +256,8 @@ async def _ensure_daily_quest_row(db: aiosqlite.Connection, user_id: int) -> Non
     )
 
     # Reset daily progress if date has rolled over
+
+    ## Removed Quiz reset from Update
     cursor = await db.execute(
         "SELECT quest_date FROM daily_quests WHERE user_id = ?",
         (user_id,),
@@ -269,7 +271,6 @@ async def _ensure_daily_quest_row(db: aiosqlite.Connection, user_id: int) -> Non
             SET quest_date = ?,
                 quizzes_completed = 0,
                 counting_numbers = 0,
-                quiz_quest_completed = 0,
                 counting_quest_completed = 0,
                 voted_today = 0,
                 quest_completed = 0


### PR DESCRIPTION
## What changed?

Removed one line from the Update action in _ensure_daily_quest_row function in codebuddy_database.py. 
This should remove the resetting of quiz scores if someone misses a day

## Why?

Wasn't a planned or desired feature

- Closes #

## How to test

Provide copy/paste commands and expected output.

## Checklist

- [ ] I linked an issue or explained why not
- [ ] I added/updated docs for user-facing changes
- [ ] I added/updated tests (or explained why not)
- [ ] I did not commit secrets (tokens, `.env`, keys)
- [ ] CI should pass for this PR

## Screenshots (optional)

If this changes UI/UX, include before/after.
