### PR TITLE
React 💯 on every counting milestone

### DIFF
--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -685,6 +685,11 @@ class Counting(commands.Cog):
                         await self._mark_highscore_message(
                             message, next_count, high_score
                         )
+
+                    # Milestone marker: react 💯 on every multiple of 100.
+                    if next_count % 100 == 0:
+                        self._enqueue_reaction(message, "💯")
+
                     return  # Success
 
             except aiosqlite.OperationalError as e:


### PR DESCRIPTION
## What changed?
Counting now reacts with 💯 whenever the count reaches a multiple of 100, in addition to the existing ✅/🏆 highscore reactions.

Closes #24

## How to test
Count up to a multiple of 100 (e.g. 100, 200) in the configured counting channel and confirm the 💯 reaction appears.