### PR TITLE
add missing command descriptions

### DIFF
--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -940,7 +940,9 @@ class Counting(commands.Cog):
         embed.description = "\n".join(lines)
         await ctx.send(embed=embed)
 
-    @commands.command(name="mcl", aliases=["tc"])
+    @commands.command(
+        name="mcl", aliases=["tc"], help="Show the top 10 users by valid counts"
+    )
     async def most_count_leaderboard(self, ctx):
         async with aiosqlite.connect(DB_PATH, timeout=30.0) as db, db.execute(
             """
@@ -967,7 +969,7 @@ class Counting(commands.Cog):
         embed.description = description
         await ctx.send(embed=embed)
 
-    @commands.command(name="mrl")
+    @commands.command(name="mrl", help="Show the top 10 users by ruined counts")
     async def most_ruined_leaderboard(self, ctx):
         async with aiosqlite.connect(DB_PATH, timeout=30.0) as db, db.execute(
             """
@@ -994,7 +996,9 @@ class Counting(commands.Cog):
         embed.description = description
         await ctx.send(embed=embed)
 
-    @commands.command(name="scs")
+    @commands.command(
+        name="scs", help="Show this server's current count and all-time high score"
+    )
     async def server_count_stats(self, ctx):
         async with aiosqlite.connect(DB_PATH, timeout=30.0) as db, db.execute(
             "SELECT current_count, high_score FROM counting_config WHERE guild_id = ?",

--- a/cogs/tod.py
+++ b/cogs/tod.py
@@ -91,11 +91,11 @@ class TOD(commands.Cog):
     async def tod_command(self, ctx: commands.Context):
         await self.send_tod_message(ctx, "random")
 
-    @commands.command(name="truth")
+    @commands.command(name="truth", help="Get a random Truth question")
     async def truth_command(self, ctx: commands.Context):
         await self.send_tod_message(ctx, "truth")
 
-    @commands.command(name="dare")
+    @commands.command(name="dare", help="Get a random Dare challenge")
     async def dare_command(self, ctx: commands.Context):
         await self.send_tod_message(ctx, "dare")
 

--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -128,7 +128,10 @@ class Say(commands.Cog):
     # LOGIN TTS NAME
     # ----------------------------
 
-    @commands.hybrid_command(name="logintts")
+    @commands.hybrid_command(
+        name="logintts",
+        description="Set the name TTS announces before your messages",
+    )
     async def logintts(self, ctx: Context, name: str):
         if len(name) > 32:
             return await ctx.send("Name too long. Max 32 characters.")
@@ -145,7 +148,9 @@ class Say(commands.Cog):
     # FORCE LEAVE VC
     # ----------------------------
 
-    @commands.hybrid_command(name="leavevc")
+    @commands.hybrid_command(
+        name="leavevc", description="Force the bot to leave its current voice channel"
+    )
     async def leavevc(self, ctx: Context):
         vc = ctx.voice_client
         if isinstance(vc, discord.VoiceClient) and vc.is_connected():
@@ -158,7 +163,9 @@ class Say(commands.Cog):
     # TTS COMMAND
     # ----------------------------
 
-    @commands.hybrid_command(name="tts")
+    @commands.hybrid_command(
+        name="tts", description="Speak your message aloud in your voice channel"
+    )
     @commands.cooldown(1, 2, commands.BucketType.user)
     async def tts(self, ctx: Context, *, text: str):
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -21,5 +21,8 @@ Store and retrieve custom text snippets.
 - **Birthdays**: `?setbirthday <DD/MM>` - Automated birthday wishes.
 - **Suggestions**: `/suggest <text>` - Creates an embed with voting reactions and a discussion thread.
 - **Disboard Tracker**: `/bumplb` - View the leaderboard for users who bump the server.
+- **Bump Stats**: `/bumpstats` - Total bumps and the most recent bumper. Also `?mybumps` and `?topbump`.
+- **Text-to-Speech**: `?logintts <name>` then `?tts <text>` - Speak in your voice channel. Use `?leavevc` to disconnect.
+- **Truth or Dare**: `?tod`, `?truth`, `?dare` - Get a random Truth or Dare prompt.
 
 [← Back to README](../README.md)

--- a/docs/GAMES.md
+++ b/docs/GAMES.md
@@ -6,7 +6,7 @@ Eigen Bot integrates multiple systems to reward active members and foster friend
 An anti-grief counting system with highscore tracking.
 - **Anti-Double Count**: Prevents users from counting twice in a row (3 warnings = fail).
 - **Save Protection**: Uses **Personal Saves** or **Server Saves** to prevent a reset to 0.
-- **Commands**: `/setcountingchannel`, `?highscoretable`, `?donateguild` (Donate 1.0 personal save to gain 0.5 server save).
+- **Commands**: `/setcountingchannel`, `?highscoretable`, `?donateguild` (Donate 1.0 personal save to gain 0.5 server save), `?guildsaves` (View server save pool), `?mcl` (Most valid counts leaderboard), `?mrl` (Most ruined counts leaderboard), `?scs` (Server count stats).
 
 ## CodeBuddy Quizzes
 Automated coding challenges to test your community's knowledge.


### PR DESCRIPTION
went through the cogs and found a handful of commands with no help text (truth, dare, logintts, leavevc, tts, mcl, mrl, scs) so they showed up blank in the help menu. added short descriptions for all of them plus a few missing entries in the docs.

closes #27, closes #47